### PR TITLE
expose waitgroup.Wait so shutdown handlers can wait on the server

### DIFF
--- a/server.go
+++ b/server.go
@@ -277,12 +277,11 @@ func (s *GracefulServer) Serve(listener net.Listener) error {
 
 	// This block is reached when the server has received a shut down command.
 	if err == nil {
-		s.wg.Wait()
 		return nil
 	} else if _, ok := err.(listenerAlreadyClosed); ok {
-		s.wg.Wait()
 		return nil
 	}
+
 	return err
 }
 
@@ -296,6 +295,10 @@ func (s *GracefulServer) StartRoutine() {
 // FinishRoutine decrements the server's WaitGroup. Used this to complement StartRoutine().
 func (s *GracefulServer) FinishRoutine() {
 	s.wg.Done()
+}
+
+func (s *GracefulServer) Wait() {
+	s.wg.Wait()
 }
 
 var (


### PR DESCRIPTION
We are running the server in a goroutine and need to `Wait` in a shutdown handler that is called in another goroutine, so this patch exposes the `Wait` method of the waitgroup. It also removes the implicit wait in `Serve` which I think should be done explicitly in the callee and not as a side-effect, but you may want to ignore this hunk for backwards compatibility.
