### PR TITLE
Fix missing TLS state

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -30,6 +30,15 @@ type gracefulConn struct {
 	lastHTTPState http.ConnState
 }
 
+type gracefulAddr struct {
+	net.Addr
+	gconn *gracefulConn
+}
+
+func (g *gracefulConn) LocalAddr() net.Addr {
+	return &gracefulAddr{g.Conn.LocalAddr(), g}
+}
+
 // A GracefulListener differs from a standard net.Listener in one way: if
 // Accept() is called after it is gracefully closed, it returns a
 // listenerAlreadyClosed error. The GracefulServer will ignore this error.
@@ -59,8 +68,12 @@ func (l *GracefulListener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 
-	gconn := &gracefulConn{conn, 0}
-	return gconn, nil
+	// don't wrap connection in case if it's tls because we won't break
+	// http server internal logic that relies on the type
+	if _, ok := conn.(*tls.Conn); ok {
+		return conn, nil
+	}
+	return &gracefulConn{conn, 0}, nil
 }
 
 // Close tells the wrapped listener to stop listening.  It is idempotent.
@@ -113,7 +126,7 @@ func (l *TLSListener) Accept() (c net.Conn, err error) {
 	if err != nil {
 		return
 	}
-	c = tls.Server(c, l.config)
+	c = tls.Server(&gracefulConn{c, 0}, l.config)
 	return
 }
 

--- a/listener.go
+++ b/listener.go
@@ -68,7 +68,7 @@ func (l *GracefulListener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 
-	// don't wrap connection in case if it's tls because we won't break
+	// don't wrap connection if it's tls so we won't break
 	// http server internal logic that relies on the type
 	if _, ok := conn.(*tls.Conn); ok {
 		return conn, nil

--- a/server.go
+++ b/server.go
@@ -230,7 +230,9 @@ func (s *GracefulServer) Serve(listener net.Listener) error {
 
 	orgConnState := s.Server.ConnState
 	s.ConnState = func(conn net.Conn, newState http.ConnState) {
-		gconn := conn.(*gracefulConn)
+		// Ugly hack, but it works. We pass the information about the underlying state via the only available interface in net.Conn
+		// we do this not to override the tls.Conn, as the internal logic of http.Server depends on the type assertion (unfortunately)
+		gconn := conn.LocalAddr().(*gracefulAddr).gconn
 		switch newState {
 		case http.StateNew:
 			// new_conn -> StateNew


### PR DESCRIPTION
Purpose
------------

Overriding the type of connection breaks the behavior of the TLS server that relies on the particular type of tls.Connection for implementing some logic here:

http://golang.org/src/net/http/server.go#L1139

Implentation
----------------

This PR preserves the original type of the connection in case of TLS connections, while still provides an access to the extended connection type

