### PR TITLE
Reject requests via kept alive connections after close

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -28,6 +28,7 @@ func NewListener(l net.Listener) *GracefulListener {
 type gracefulConn struct {
 	net.Conn
 	lastHTTPState http.ConnState
+	forceClosed   bool
 }
 
 type gracefulAddr struct {
@@ -37,6 +38,13 @@ type gracefulAddr struct {
 
 func (g *gracefulConn) LocalAddr() net.Addr {
 	return &gracefulAddr{g.Conn.LocalAddr(), g}
+}
+
+// retrieveGracefulConn retrieves a concrete gracefulConn instance from an
+// interface value that can either refer to it directly or refer to a tls.Conn
+// instance wrapping around a gracefulConn one.
+func retrieveGracefulConn(conn net.Conn) *gracefulConn {
+	return conn.LocalAddr().(*gracefulAddr).gconn
 }
 
 // A GracefulListener differs from a standard net.Listener in one way: if
@@ -73,7 +81,7 @@ func (l *GracefulListener) Accept() (net.Conn, error) {
 	if _, ok := conn.(*tls.Conn); ok {
 		return conn, nil
 	}
-	return &gracefulConn{conn, 0}, nil
+	return &gracefulConn{Conn: conn}, nil
 }
 
 // Close tells the wrapped listener to stop listening.  It is idempotent.
@@ -126,7 +134,7 @@ func (l *TLSListener) Accept() (c net.Conn, err error) {
 	if err != nil {
 		return
 	}
-	c = tls.Server(&gracefulConn{c, 0}, l.config)
+	c = tls.Server(&gracefulConn{Conn: c}, l.config)
 	return
 }
 


### PR DESCRIPTION
### Problem
After a graceful server is stopped, kept alive connections are left hanging. Each of them allow one more request to be processed, after that they are closed thanks to  `SetKeepAlivesEnabled(false)`. But that one request (per connection) can still screw things up if e.g. it sends to a channel that you already closed since supposedly the http server has stopped gracefully.

### Solution
Graceful server should reject requests coming through kept alive connections with sensible result code. I have chosen **503 Service Unavailable** for this purpose.