### PR TITLE
Connections in StateNew that transition to StateActive after closing cause shutdown to fail

### DIFF
--- a/server.go
+++ b/server.go
@@ -240,7 +240,7 @@ func (s *GracefulServer) Serve(listener net.Listener) error {
 			// (StateNew, StateIdle) -> StateActive
 			if gracefulHandler.IsClosed() {
 				gracefulConn.Close()
-				gracefulConn.forceClosed = true
+				gracefulConn.forceClosed = (oldState == http.StateIdle)
 			} else {
 				if oldState == http.StateIdle {
 					s.StartRoutine()


### PR DESCRIPTION
If the gracefulHandler is closed after a new connection is made but before it becomes active it will call StartRoutine but not EndRoutine.

