### PR TITLE
Make sure that FinishRoutine is always called

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -28,7 +28,9 @@ func NewListener(l net.Listener) *GracefulListener {
 type gracefulConn struct {
 	net.Conn
 	lastHTTPState http.ConnState
-	forceClosed   bool
+	// protected tells whether the connection is going to defer server shutdown
+	// until the current HTTP request is completed.
+	protected bool
 }
 
 type gracefulAddr struct {


### PR DESCRIPTION
@epipho found a race condition where if a server is closed right after a new connection is created, but just before the connection gets into the Active state, FinishRoutine is not called. In #6 he proposed a solution, but I suggest making it a bit more explicit.

I even wanted to make a connection protected on **any-->active** transition and complete protection on **active-->any** transition. That would be a more elegant solution with less if/else branches, but that requires significant refactoring of unit tests that I have no time for right now.