### PR TITLE
Merge test helper changes from the upstream

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -1,0 +1,7 @@
+package manners
+
+type waitGroup interface {
+	Add(int)
+	Done()
+	Wait()
+}

--- a/server.go
+++ b/server.go
@@ -110,7 +110,7 @@ func NewWithOptions(o Options) *GracefulServer {
 type GracefulServer struct {
 	*http.Server
 	shutdown     chan struct{}
-	wg           waitgroup
+	wg           waitGroup
 	listener     *GracefulListener
 	stateHandler StateHandler
 

--- a/server_test.go
+++ b/server_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/mailgun/manners/test_helpers"
 )
 
 type httpInterface interface {
@@ -30,7 +32,7 @@ func TestInterface(t *testing.T) {
 func TestGracefulness(t *testing.T) {
 	server := newServer()
 	stateChangedCh := make(chan http.ConnState)
-	wg := newTestWg()
+	wg := test_helpers.NewWaitGroup()
 	server.wg = wg
 	listener, exitchan := startServer(t, server, stateChangedCh)
 
@@ -47,7 +49,7 @@ func TestGracefulness(t *testing.T) {
 
 	server.Close()
 
-	waiting := <-wg.waitCalled
+	waiting := <-wg.WaitCalled
 	if waiting < 1 {
 		t.Errorf("Expected the waitgroup to equal 1 at shutdown; actually %d", waiting)
 	}
@@ -78,7 +80,7 @@ func waitForState(t *testing.T, waiter chan http.ConnState, state http.ConnState
 // network connection still results in a corect shutdown
 func TestStateTransitionActiveIdleActive(t *testing.T) {
 	server := newServer()
-	wg := newTestWg()
+	wg := test_helpers.NewWaitGroup()
 	statechanged := make(chan http.ConnState)
 	server.wg = wg
 	listener, exitchan := startServer(t, server, statechanged)
@@ -101,7 +103,7 @@ func TestStateTransitionActiveIdleActive(t *testing.T) {
 	// client is now in an idle state
 
 	server.Close()
-	waiting := <-wg.waitCalled
+	waiting := <-wg.WaitCalled
 	if waiting != 0 {
 		t.Errorf("Waitcount should be zero, got %d", waiting)
 	}
@@ -148,8 +150,8 @@ func TestStateTransitionActiveIdleClosed(t *testing.T) {
 		exitchan chan error
 	)
 
-	keyFile, err1 := newTempFile(localhostKey)
-	certFile, err2 := newTempFile(localhostCert)
+	keyFile, err1 := test_helpers.NewTempFile(test_helpers.Key)
+	certFile, err2 := test_helpers.NewTempFile(test_helpers.Cert)
 	defer keyFile.Unlink()
 	defer certFile.Unlink()
 
@@ -159,7 +161,7 @@ func TestStateTransitionActiveIdleClosed(t *testing.T) {
 
 	for _, withTLS := range []bool{false, true} {
 		server := newServer()
-		wg := newTestWg()
+		wg := test_helpers.NewWaitGroup()
 		statechanged := make(chan http.ConnState)
 		server.wg = wg
 		if withTLS {
@@ -192,7 +194,7 @@ func TestStateTransitionActiveIdleClosed(t *testing.T) {
 		waitForState(t, statechanged, http.StateClosed, "Client failed to reach closed state")
 
 		server.Close()
-		waiting := <-wg.waitCalled
+		waiting := <-wg.WaitCalled
 		if waiting != 0 {
 			t.Errorf("Waitcount should be zero, got %d", waiting)
 		}
@@ -252,7 +254,7 @@ func TestWrapConnection(t *testing.T) {
 func TestShutdown(t *testing.T) {
 	server := NewServer()
 	stateChangedCh := make(chan http.ConnState)
-	wg := newTestWg()
+	wg := test_helpers.NewWaitGroup()
 	server.wg = wg
 	listener, exitchan := startServer(t, server, stateChangedCh)
 
@@ -271,7 +273,7 @@ func TestShutdown(t *testing.T) {
 	// the listener should of been closed, though client1 is still connected
 	server.Close()
 
-	waiting := <-wg.waitCalled
+	waiting := <-wg.WaitCalled
 	if waiting != 1 {
 		t.Errorf("Waitcount should be one, got %d", waiting)
 	}
@@ -302,15 +304,15 @@ func TestGlobalShutdown(t *testing.T) {
 	}()
 
 	go func() {
-		keyFile, _ := newTempFile(localhostKey)
-		certFile, _ := newTempFile(localhostCert)
+		keyFile, _ := test_helpers.NewTempFile(test_helpers.Key)
+		certFile, _ := test_helpers.NewTempFile(test_helpers.Cert)
 		defer keyFile.Unlink()
 		defer certFile.Unlink()
 		lastlserr <- ListenAndServeTLS("127.0.0.1:0", certFile.Name(), keyFile.Name(), nullHandler)
 	}()
 
 	go func() {
-		l := newFakeListener()
+		l := test_helpers.NewListener()
 		serveerr <- Serve(l, nullHandler)
 	}()
 
@@ -355,7 +357,7 @@ func TestGlobalShutdown(t *testing.T) {
 // Hijack listener
 func TestHijackListener(t *testing.T) {
 	server := NewServer()
-	wg := newTestWg()
+	wg := test_helpers.NewWaitGroup()
 	server.wg = wg
 	listener, exitchan := startServer(t, server, nil)
 
@@ -368,9 +370,9 @@ func TestHijackListener(t *testing.T) {
 	}
 
 	// Make sure server1 got the request and added it to the waiting group
-	<-wg.countChanged
+	<-wg.CountChanged
 
-	wg2 := newTestWg()
+	wg2 := test_helpers.NewWaitGroup()
 	server2, err := server.HijackListener(new(http.Server), nil)
 	server2.wg = wg2
 	if err != nil {
@@ -383,7 +385,7 @@ func TestHijackListener(t *testing.T) {
 	server.Close()
 
 	// First server waits for the first request to finish
-	waiting := <-wg.waitCalled
+	waiting := <-wg.WaitCalled
 	if waiting < 1 {
 		t.Errorf("Expected the waitgroup to equal 1 at shutdown; actually %d", waiting)
 	}
@@ -412,7 +414,7 @@ func TestHijackListener(t *testing.T) {
 	// Close the second server
 	server2.Close()
 
-	waiting = <-wg2.waitCalled
+	waiting = <-wg2.WaitCalled
 	if waiting < 1 {
 		t.Errorf("Expected the waitgroup to equal 1 at shutdown; actually %d", waiting)
 	}

--- a/test_helpers/certs.go
+++ b/test_helpers/certs.go
@@ -1,55 +1,12 @@
-package manners
+package test_helpers
 
-import (
-	"errors"
-	"net"
-)
+// A PEM-encoded TLS cert with SAN IPs "127.0.0.1" and "[::1]", expiring at the
+// last second of 2049 (the end of ASN.1 time).
 
-type fakeConn struct {
-	net.Conn
-	closeCalled bool
-	localAddr   net.Addr
-}
-
-func (f *fakeConn) LocalAddr() net.Addr {
-	return &net.IPAddr{}
-}
-
-func (c *fakeConn) Close() error {
-	c.closeCalled = true
-	return nil
-}
-
-type fakeListener struct {
-	acceptRelease chan bool
-	closeCalled   chan bool
-}
-
-func newFakeListener() *fakeListener { return &fakeListener{make(chan bool, 1), make(chan bool, 1)} }
-
-func (l *fakeListener) Addr() net.Addr {
-	addr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:8080")
-	return addr
-}
-
-func (l *fakeListener) Close() error {
-	l.closeCalled <- true
-	l.acceptRelease <- true
-	return nil
-}
-
-func (l *fakeListener) Accept() (net.Conn, error) {
-	<-l.acceptRelease
-	return nil, errors.New("connection closed")
-}
-
-// localhostCert is a PEM-encoded TLS cert with SAN IPs
-// "127.0.0.1" and "[::1]", expiring at the last second of 2049 (the end
-// of ASN.1 time).
 // generated from src/pkg/crypto/tls:
 // go run generate_cert.go  --rsa-bits 512 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
 var (
-	localhostCert = []byte(`-----BEGIN CERTIFICATE-----
+	Cert = []byte(`-----BEGIN CERTIFICATE-----
 MIIBdzCCASOgAwIBAgIBADALBgkqhkiG9w0BAQUwEjEQMA4GA1UEChMHQWNtZSBD
 bzAeFw03MDAxMDEwMDAwMDBaFw00OTEyMzEyMzU5NTlaMBIxEDAOBgNVBAoTB0Fj
 bWUgQ28wWjALBgkqhkiG9w0BAQEDSwAwSAJBAN55NcYKZeInyTuhcCwFMhDHCmwa
@@ -60,7 +17,7 @@ AAAAAAAAAAAAAAEwCwYJKoZIhvcNAQEFA0EAAoQn/ytgqpiLcZu9XKbCJsJcvkgk
 Se6AbGXgSlq+ZCEVo0qIwSgeBqmsJxUu7NCSOwVJLYNEBO2DtIxoYVk+MA==
 -----END CERTIFICATE-----`)
 
-	localhostKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+	Key = []byte(`-----BEGIN RSA PRIVATE KEY-----
 MIIBPAIBAAJBAN55NcYKZeInyTuhcCwFMhDHCmwaIUSdtXdcbItRB/yfXGBhiex0
 0IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEAAQJBAQdUx66rfh8sYsgfdcvV
 NoafYpnEcB5s4m/vSVe6SU7dCK6eYec9f9wpT353ljhDUHq3EbmE4foNzJngh35d

--- a/test_helpers/conn.go
+++ b/test_helpers/conn.go
@@ -1,0 +1,18 @@
+package test_helpers
+
+import "net"
+
+type Conn struct {
+	net.Conn
+	closeCalled bool
+	localAddr   net.Addr
+}
+
+func (f *Conn) LocalAddr() net.Addr {
+	return &net.IPAddr{}
+}
+
+func (c *Conn) Close() error {
+	c.closeCalled = true
+	return nil
+}

--- a/test_helpers/listener.go
+++ b/test_helpers/listener.go
@@ -1,0 +1,34 @@
+package test_helpers
+
+import (
+	"errors"
+	"net"
+)
+
+type Listener struct {
+	AcceptRelease chan bool
+	CloseCalled   chan bool
+}
+
+func NewListener() *Listener {
+	return &Listener{
+		make(chan bool, 1),
+		make(chan bool, 1),
+	}
+}
+
+func (l *Listener) Addr() net.Addr {
+	addr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:8080")
+	return addr
+}
+
+func (l *Listener) Close() error {
+	l.CloseCalled <- true
+	l.AcceptRelease <- true
+	return nil
+}
+
+func (l *Listener) Accept() (net.Conn, error) {
+	<-l.AcceptRelease
+	return nil, errors.New("connection closed")
+}

--- a/test_helpers/temp_file.go
+++ b/test_helpers/temp_file.go
@@ -1,0 +1,27 @@
+package test_helpers
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+type TempFile struct {
+	*os.File
+}
+
+func NewTempFile(content []byte) (*TempFile, error) {
+	f, err := ioutil.TempFile("", "graceful-test")
+	if err != nil {
+		return nil, err
+	}
+
+	f.Write(content)
+	return &TempFile{f}, nil
+}
+
+func (tf *TempFile) Unlink() {
+	if tf.File != nil {
+		os.Remove(tf.Name())
+		tf.File = nil
+	}
+}

--- a/test_helpers/wait_group.go
+++ b/test_helpers/wait_group.go
@@ -1,10 +1,10 @@
-package manners
+package test_helpers
 
 import (
 	"sync"
 )
 
-type waitgroup interface {
+type WaitGroup interface {
 	Add(int)
 	Done()
 	Wait()
@@ -14,33 +14,33 @@ type waitgroup interface {
 type testWg struct {
 	sync.Mutex
 	count        int
-	waitCalled   chan int
-	countChanged chan int
+	WaitCalled   chan int
+	CountChanged chan int
 }
 
-func newTestWg() *testWg {
+func NewWaitGroup() *testWg {
 	return &testWg{
-		waitCalled:   make(chan int, 1),
-		countChanged: make(chan int, 1024),
+		WaitCalled:   make(chan int, 1),
+		CountChanged: make(chan int, 1024),
 	}
 }
 
 func (wg *testWg) Add(delta int) {
 	wg.Lock()
 	wg.count++
-	wg.countChanged <- wg.count
+	wg.CountChanged <- wg.count
 	wg.Unlock()
 }
 
 func (wg *testWg) Done() {
 	wg.Lock()
 	wg.count--
-	wg.countChanged <- wg.count
+	wg.CountChanged <- wg.count
 	wg.Unlock()
 }
 
 func (wg *testWg) Wait() {
 	wg.Lock()
-	wg.waitCalled <- wg.count
+	wg.WaitCalled <- wg.count
 	wg.Unlock()
 }

--- a/transition_test.go
+++ b/transition_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/mailgun/manners/test_helpers"
 )
 
 func TestStateTransitions(t *testing.T) {
@@ -31,17 +33,17 @@ type transitionTest struct {
 
 func testStateTransition(t *testing.T, test transitionTest) {
 	server := newServer()
-	wg := newTestWg()
+	wg := test_helpers.NewWaitGroup()
 	server.wg = wg
 	startServer(t, server, nil)
 
-	conn := &gracefulConn{Conn: &fakeConn{}}
+	conn := &gracefulConn{Conn: &test_helpers.Conn{}}
 	for _, newState := range test.states {
 		server.ConnState(conn, newState)
 	}
 
 	server.Close()
-	waiting := <-wg.waitCalled
+	waiting := <-wg.WaitCalled
 	if waiting != test.expectedWgCount {
 		names := make([]string, len(test.states))
 		for i, s := range test.states {


### PR DESCRIPTION
The main purpose of this PR is to make sure that names of all test related files in the main package end with **_test.go**. Original naming such as **test_helpers.go** made them included into the production builds of applications using **manners** HTTP servers. That would not be an issue if **test_helpers.go** did not import the **testing** package. But it did, and the result was that a bunch of **-test.xxx" command line parameters was added to the command line parameters of the application.