### PR TITLE
Implement TCPKeepAliveListener for plaintext sockets as well

### DIFF
--- a/server.go
+++ b/server.go
@@ -142,7 +142,7 @@ func (gs *GracefulServer) ListenAndServe() error {
 		if err != nil {
 			return err
 		}
-		gs.listener = NewListener(oldListener.(*net.TCPListener))
+		gs.listener = NewListener(TCPKeepAliveListener{oldListener.(*net.TCPListener)})
 	}
 	return gs.Serve(gs.listener)
 }


### PR DESCRIPTION
This removed line documented that TCPKeepAliveListener should've been used with the plaintext socket as well: https://github.com/mailgun/manners/commit/448d7b595e3f90682487e112905a38b19f22fbb7#diff-804732da4aad8a84ebedfb545342f187L60

I've now added it to the plaintext socket, because I hit Azure's disgusting "disconnect sockets with inactivity for 4 minutes" **feature** here, when fronted by Cloudflare: https://github.com/containous/traefik/issues/1046